### PR TITLE
fix(chat): correct navigation link in chat list

### DIFF
--- a/templates/chat/list.html
+++ b/templates/chat/list.html
@@ -7,7 +7,7 @@
     <div class="chat-list">
         {% if chats %}
             {% for chat in chats %}
-            <a href="#" class="chat-item-link">
+            <a href="{{ url_for('main.chat_room', room_id=chat.id) }}" class="chat-item-link">
                 <div class="chat-item">
                     <div class="chat-item-avatar">
                         <img src="{{ chat.avatar_url }}" alt="{{ chat.name }}">


### PR DESCRIPTION
The chat list items in `templates/chat/list.html` were not linking to the individual chat rooms due to a placeholder `href`.

This commit replaces the static `href="#"` with a dynamic `url_for` call to generate the correct link for each chat room, restoring the core navigation functionality of the chat feature.