### PR TITLE
Fix TypeError when displaying status view count

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -31,7 +31,7 @@
                                 {{ status.content_type|capitalize }} posted at {{ status.created_at.strftime('%H:%M') }}
                             {% endif %}
                         </p>
-                        <p class="seen-by"><i class="fa-solid fa-eye"></i> Seen by {{ status.views|length }}</p>
+                        <p class="seen-by"><i class="fa-solid fa-eye"></i> Seen by {{ status.views.count() }}</p>
                     </div>
                 </div>
             </a>


### PR DESCRIPTION
The `status.views` attribute is a SQLAlchemy AppenderQuery object because the relationship is loaded with `lazy='dynamic'`. The `|length` filter in Jinja2 cannot be used on this type of object.

This commit replaces `status.views|length` with `status.views.count()` in the `templates/status.html` template. The `.count()` method correctly executes a query to get the number of views for a status, resolving the `TypeError`.