### PR TITLE
Fix non-functional send button in chat room

### DIFF
--- a/templates/chat/room.html
+++ b/templates/chat/room.html
@@ -1685,6 +1685,37 @@ document.addEventListener('DOMContentLoaded', function() {
         contextMenu.classList.add('hidden');
     });
 
+    // --- Send Message Logic ---
+    const sendBtn = document.querySelector('.send-btn');
+    const messageInputForSend = document.querySelector('.message-input');
+
+    function sendMessage() {
+        const content = messageInputForSend.value.trim();
+        if (content) {
+            // Stop typing indicator when message is sent
+            socket.emit('typing_stop', { room_id: {{ chat_info.id|tojson }} });
+
+            socket.emit('message', {
+                room_id: {{ chat_info.id|tojson }},
+                content: content
+            });
+            messageInputForSend.value = '';
+            messageInputForSend.style.height = 'auto'; // Reset height
+        }
+    }
+
+    if (sendBtn && messageInputForSend) {
+        sendBtn.addEventListener('click', sendMessage);
+
+        messageInputForSend.addEventListener('keydown', function(event) {
+            if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                sendMessage();
+            }
+        });
+    }
+
+
     document.getElementById('forward-menu-item').addEventListener('click', async function() {
         if (!currentForwardMessageId) return;
 


### PR DESCRIPTION
The send button in the chat room was not sending messages because it was missing a JavaScript click event listener.

This commit adds the necessary JavaScript to `templates/chat/room.html`. An event listener is attached to the send button to emit a 'message' event via Socket.IO when clicked. A 'keydown' event listener is also added to the message input field to allow sending messages by pressing the Enter key.