### PR TITLE
feat: Redesign feed navigation bar

### DIFF
--- a/static/css/feed_world.css
+++ b/static/css/feed_world.css
@@ -230,3 +230,65 @@ body {
     background-color: #fff3cd;
     border-color: #ffeeba;
 }
+
+/*--------------------------------------------------------------
+# Centered Navigation Item
+--------------------------------------------------------------*/
+.nav-item-center {
+    /* Transform to raise the button */
+    transform: translateY(-10px);
+    border-radius: 50%;
+    background: var(--primary-gradient, var(--primary-color));
+    border: 3px solid var(--card-bg-light);
+    color: white;
+    width: 50px; /* Set a fixed width */
+    height: 50px; /* Set a fixed height */
+    flex-grow: 0 !important; /* Prevent it from growing */
+    margin: 0 10px; /* Add some margin */
+}
+
+.nav-item-center:hover, .nav-item-center.active {
+    color: white;
+    /* Optional: Add a subtle shadow or glow on hover/active */
+    box-shadow: 0 0 10px rgba(74, 105, 189, 0.7);
+}
+
+.nav-item-center i {
+    font-size: 1.8rem; /* Larger icon */
+}
+
+.nav-item-center span {
+    display: none; /* Hide the text label for the center button */
+}
+
+/*--------------------------------------------------------------
+# More Menu Page
+--------------------------------------------------------------*/
+.more-menu-list {
+    list-style: none;
+    padding: 0;
+    margin: 20px 0;
+}
+
+.more-menu-list li a {
+    display: flex;
+    align-items: center;
+    padding: 15px;
+    text-decoration: none;
+    color: var(--primary-text-light);
+    border-radius: var(--border-radius);
+    transition: background-color 0.2s;
+    font-size: 1.1rem;
+}
+
+.more-menu-list li a:hover {
+    background-color: var(--hover-overlay-light);
+}
+
+.more-menu-list li i {
+    font-size: 1.5rem;
+    margin-right: 20px;
+    width: 30px;
+    text-align: center;
+    color: var(--primary-color);
+}

--- a/templates/feed/base.html
+++ b/templates/feed/base.html
@@ -66,21 +66,13 @@
             <i class="fas fa-home"></i>
             <span>Home</span>
         </a>
-        <a href="{{ url_for('feed.communities') }}" class="nav-item {{ 'active' if request.endpoint == 'feed.communities' }}">
-            <i class="fas fa-users"></i>
-            <span>Communities</span>
-        </a>
-        <a href="{{ url_for('feed.innovation') }}" class="nav-item {{ 'active' if request.endpoint == 'feed.innovation' }}">
-            <i class="fas fa-lightbulb"></i>
-            <span>Innovation</span>
-        </a>
-        <a href="{{ url_for('feed.creativity') }}" class="nav-item {{ 'active' if request.endpoint == 'feed.creativity' }}">
-            <i class="fas fa-palette"></i>
-            <span>Creativity</span>
-        </a>
-         <a href="{{ url_for('feed.profile') }}" class="nav-item {{ 'active' if request.endpoint == 'feed.profile' }}">
+        <a href="{{ url_for('feed.profile') }}" class="nav-item {{ 'active' if request.endpoint == 'feed.profile' }}">
             <i class="fas fa-user"></i>
             <span>Profile</span>
+        </a>
+        <a href="{{ url_for('feed.creativity') }}" class="nav-item nav-item-center {{ 'active' if request.endpoint == 'feed.creativity' }}">
+            <i class="fa-brands fa-tiktok"></i>
+            <span>Creativity</span>
         </a>
         <a href="{{ url_for('feed.suggestions') }}" class="nav-item {{ 'active' if request.endpoint == 'feed.suggestions' }}">
             <i class="fas fa-user-plus"></i>

--- a/templates/feed/more.html
+++ b/templates/feed/more.html
@@ -5,6 +5,22 @@
 {% block content %}
 <div class="feed-container">
     <h1>More Options</h1>
-    <p>Settings, privacy, and other extras will be available here. This section is under construction.</p>
+    <div class="more-menu">
+        <ul class="more-menu-list">
+            <li>
+                <a href="{{ url_for('feed.communities') }}">
+                    <i class="fas fa-users"></i>
+                    <span>Communities</span>
+                </a>
+            </li>
+            <li>
+                <a href="{{ url_for('feed.innovation') }}">
+                    <i class="fas fa-lightbulb"></i>
+                    <span>Innovation</span>
+                </a>
+            </li>
+            <!-- Add more links here in the future -->
+        </ul>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This commit redesigns the bottom navigation bar in the social feed based on user feedback.

- Moves the "Communities" and "Innovation" links from the main navigation bar to the "More" page to reduce clutter.
- Repositions the "Creativity" link to be the central item in the navigation bar.
- Changes the "Creativity" icon to a TikTok-style icon (`fa-brands fa-tiktok`) from Font Awesome.
- Adds custom CSS to style the new central "Creativity" button, making it larger, circular, and visually prominent.
- Updates the "More" page to include the moved links, ensuring functionality is retained.