### PR TITLE
feat: Implement 'Advanced Post Analytics' for Premium Users

### DIFF
--- a/models.py
+++ b/models.py
@@ -855,6 +855,19 @@ class PinnedPost(db.Model):
         return f'<PinnedPost for User {self.user_id} - Post {self.post_id}>'
 
 
+class PostImpression(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    post_id = db.Column(db.Integer, db.ForeignKey('post.id'), nullable=False, index=True)
+    viewer_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True, index=True) # Nullable for anonymous viewers
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow, index=True)
+
+    post = db.relationship('Post', backref=db.backref('impressions', lazy='dynamic'))
+    viewer = db.relationship('User', backref=db.backref('post_views', lazy='dynamic'))
+
+    def __repr__(self):
+        return f'<PostImpression on Post {self.post_id} by User {self.viewer_id}>'
+
+
 # --- "More" Page Feature Models ---
 
 class UserPage(db.Model):

--- a/templates/feed/_post_content.html
+++ b/templates/feed/_post_content.html
@@ -21,6 +21,9 @@
     <div class="post-more-options">
         <button class="icon-btn more-options-btn"><i class="fas fa-ellipsis-h"></i></button>
         <ul class="more-options-menu">
+            {% if post.author == current_user and current_user.is_premium %}
+            <li><a href="#" class="view-analytics-btn" data-post-id="{{ post.id }}">View Analytics</a></li>
+            {% endif %}
             <li><a href="#" class="report-post-btn" data-post-id="{{ post.id }}">Report Post</a></li>
             <!-- Add other options like 'Edit' or 'Delete' here if needed -->
         </ul>

--- a/templates/feed/home.html
+++ b/templates/feed/home.html
@@ -332,6 +332,17 @@
         </form>
     </div>
 </div>
+
+<!-- Analytics Modal -->
+<div id="analytics-modal" class="modal">
+    <div class="modal-content">
+        <span class="close-btn analytics-close">&times;</span>
+        <h2>Post Analytics</h2>
+        <div id="analytics-content">
+            <p>Loading analytics...</p>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
@@ -613,6 +624,114 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
     updateTimestamps();
+
+    // --- Analytics Modal Logic ---
+    const analyticsModal = document.getElementById('analytics-modal');
+    if (analyticsModal) {
+        const analyticsCloseBtn = analyticsModal.querySelector('.analytics-close');
+        const analyticsContent = document.getElementById('analytics-content');
+
+        document.querySelectorAll('.view-analytics-btn').forEach(btn => {
+            btn.addEventListener('click', function(event) {
+                event.preventDefault();
+                event.stopPropagation();
+
+                const postId = this.dataset.postId;
+                analyticsModal.style.display = 'block';
+                analyticsContent.innerHTML = '<p>Loading analytics...</p>';
+
+                fetch(`/feed/api/post/${postId}/analytics`)
+                    .then(response => {
+                        if (!response.ok) {
+                            throw new Error('Failed to load analytics.');
+                        }
+                        return response.json();
+                    })
+                    .then(data => {
+                        analyticsContent.innerHTML = `
+                            <ul class="list-group">
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    Impressions
+                                    <span class="badge badge-primary badge-pill">${data.impressions}</span>
+                                </li>
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    Reach (Unique Viewers)
+                                    <span class="badge badge-primary badge-pill">${data.reach}</span>
+                                </li>
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    Total Engagement
+                                    <span class="badge badge-primary badge-pill">${data.engagement}</span>
+                                </li>
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    &nbsp;&nbsp;&nbsp;Likes
+                                    <span class="badge badge-secondary badge-pill">${data.likes}</span>
+                                </li>
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    &nbsp;&nbsp;&nbsp;Comments
+                                    <span class="badge badge-secondary badge-pill">${data.comments}</span>
+                                </li>
+                            </ul>
+                            <h5 class="mt-4">Engagement by Role (from Likes)</h5>
+                            <ul class="list-group">
+                                ${Object.entries(data.demographics).map(([role, count]) => `
+                                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                                        ${role.charAt(0).toUpperCase() + role.slice(1)}s
+                                        <span class="badge badge-info badge-pill">${count}</span>
+                                    </li>
+                                `).join('')}
+                                ${Object.keys(data.demographics).length === 0 ? '<li class="list-group-item">No engagement data by role yet.</li>' : ''}
+                            </ul>
+                        `;
+                    })
+                    .catch(error => {
+                        analyticsContent.innerHTML = `<p class="text-danger">${error.message}</p>`;
+                    });
+
+                this.closest('.more-options-menu').style.display = 'none';
+            });
+        });
+
+        analyticsCloseBtn.onclick = function() {
+            analyticsModal.style.display = 'none';
+        }
+
+        // Also close modal when clicking outside of it
+        window.addEventListener('click', (event) => {
+            if (event.target == analyticsModal) {
+                analyticsModal.style.display = 'none';
+            }
+        });
+    }
+
+    // --- Impression Tracking Logic ---
+    const observerOptions = {
+        root: null, // relative to the viewport
+        rootMargin: '0px',
+        threshold: 0.75 // Trigger when 75% of the post is visible
+    };
+
+    const impressionObserver = new IntersectionObserver((entries, observer) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                const postContainer = entry.target;
+                const postId = postContainer.dataset.postId;
+
+                if (!postContainer.dataset.impressionSent) {
+                    postContainer.dataset.impressionSent = 'true';
+                    fetch(`/feed/api/post/${postId}/impression`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                    }).catch(err => console.error('Impression tracking failed:', err));
+
+                    observer.unobserve(postContainer);
+                }
+            }
+        });
+    }, observerOptions);
+
+    document.querySelectorAll('.post-container').forEach(post => {
+        impressionObserver.observe(post);
+    });
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
This commit introduces the 'Advanced Post Analytics' feature, another benefit of the Premium Plan.

Key features include:
- A new `PostImpression` model to track post views.
- An API endpoint (`/api/post/<int:post_id>/impression`) to record impressions. This is called by a new `IntersectionObserver` on the frontend to efficiently track when posts become visible to the user.
- A new API endpoint (`/api/post/<int:post_id>/analytics`) that calculates and returns key metrics for a post. This is secured to only be accessible by the post's author if they are a premium user.
- The analytics data includes total impressions, unique reach (viewers), total engagement (likes + comments), and a simple demographic breakdown of engagement by user role.
- A "View Analytics" button is now available in the post options menu for premium authors, which opens a modal to display this data.

This provides a solid foundation for post analytics that can be expanded upon in the future.