### PR TITLE
feat: Implement Profile & Identity section

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,7 +1,9 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, TextAreaField, SubmitField, SelectField
-from wtforms.validators import DataRequired, Email, Optional, URL, Length
+from wtforms import StringField, TextAreaField, SubmitField, SelectField, PasswordField
+from wtforms.validators import DataRequired, Email, Optional, URL, Length, Regexp, ValidationError, EqualTo
 from flask_wtf.file import FileField, FileAllowed, FileRequired
+from models import User
+from flask_login import current_user
 
 class PageCreationStep1Form(FlaskForm):
     name = StringField('Page Name', validators=[DataRequired(), Length(min=3, max=100)])
@@ -62,3 +64,38 @@ class ProfileAppearanceForm(FlaskForm):
                               validators=[Optional()])
     pinned_post = SelectField('Pinned Post', coerce=int, validators=[Optional()])
     submit = SubmitField('Save Changes')
+
+class EditProfileForm(FlaskForm):
+    name = StringField('Display Name', validators=[DataRequired(), Length(min=2, max=50)])
+    username = StringField('Username', validators=[
+        DataRequired(),
+        Length(min=3, max=30),
+        Regexp('^[a-zA-Z0-9_.]*$', message='Username can only contain letters, numbers, dots, and underscores.')
+    ])
+    website = StringField('Website', validators=[Optional(), URL()])
+    bio = TextAreaField('Bio', validators=[Optional(), Length(max=160)])
+    profile_photo = FileField('Profile Photo', validators=[
+        FileAllowed(['jpg', 'png', 'jpeg'], 'Images only!')
+    ])
+    cover_photo = FileField('Cover Photo', validators=[
+        FileAllowed(['jpg', 'png', 'jpeg'], 'Images only!')
+    ])
+    submit = SubmitField('Save Changes')
+
+    def validate_username(self, username):
+        if username.data != current_user.username:
+            user = User.query.filter_by(username=username.data).first()
+            if user:
+                raise ValidationError('That username is taken. Please choose a different one.')
+
+class ChangePasswordForm(FlaskForm):
+    current_password = PasswordField('Current Password', validators=[DataRequired()])
+    new_password = PasswordField('New Password', validators=[
+        DataRequired(),
+        Length(min=8, message='Password must be at least 8 characters long.')
+    ])
+    confirm_password = PasswordField('Confirm New Password', validators=[
+        DataRequired(),
+        EqualTo('new_password', message='Passwords must match.')
+    ])
+    submit = SubmitField('Change Password')

--- a/models.py
+++ b/models.py
@@ -27,8 +27,12 @@ class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     name = db.Column(db.String(150), nullable=False)
+    username = db.Column(db.String(80), unique=True, nullable=True)
     email = db.Column(db.String(150), unique=True, nullable=False)
+    email_verified = db.Column(db.Boolean, default=False, nullable=False)
+    phone_number = db.Column(db.String(20), nullable=True, unique=True)
     password_hash = db.Column(db.String(128))
+    website = db.Column(db.String(200), nullable=True)
     role = db.Column(db.String(50), nullable=False, default='student')
     approved = db.Column(db.Boolean, default=False)
     is_banned = db.Column(db.Boolean, default=False)
@@ -50,6 +54,7 @@ class User(UserMixin, db.Model):
     premium_expires_at = db.Column(db.DateTime, nullable=True)
 
     # Custom Profile Appearance
+    cover_photo = db.Column(db.String(120), nullable=True, default='images/course_placeholder.jpg')
     profile_banner_url = db.Column(db.String(255), nullable=True)
     profile_theme = db.Column(db.String(50), nullable=True)
     bio_links = db.Column(db.JSON, nullable=True)

--- a/templates/more/account_settings.html
+++ b/templates/more/account_settings.html
@@ -1,0 +1,137 @@
+{% extends "feed/base.html" %}
+{% from "_form_helpers.html" import render_field %}
+
+{% block title %}Account Settings{% endblock %}
+
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/forms.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/settings.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="card settings-card">
+        <div class="card-header">
+            <h1>Account Settings</h1>
+            <p class="text-muted mb-0">Manage your credentials, contact information, and account status.</p>
+        </div>
+        <div class="card-body">
+            <!-- Email Address -->
+            <div class="settings-section">
+                <div class="settings-section-header">
+                    <h5>Email Address</h5>
+                </div>
+                <div class="settings-section-content">
+                    <p>
+                        {{ current_user.email }}
+                        {% if current_user.email_verified %}
+                            <span class="badge bg-success">Verified</span>
+                        {% else %}
+                            <span class="badge bg-warning text-dark">Not Verified</span>
+                            <a href="{{ url_for('auth.resend_verification_email') }}" class="small ms-2">Resend verification email</a>
+                        {% endif %}
+                    </p>
+                    <small class="text-muted">Your email is used for login, notifications, and account recovery.</small>
+                </div>
+            </div>
+
+            <!-- Phone Number -->
+            <div class="settings-section">
+                <div class="settings-section-header">
+                    <h5>Phone Number</h5>
+                </div>
+                <div class="settings-section-content">
+                    {% if current_user.phone_number %}
+                        <p>{{ current_user.phone_number }} <span class="badge bg-success">Verified</span></p>
+                        <a href="#" class="btn btn-sm btn-outline-secondary">Change Number</a>
+                    {% else %}
+                        <p class="text-muted">You have not added a phone number.</p>
+                        <a href="#" class="btn btn-sm btn-outline-primary">Add Phone Number</a>
+                    {% endif %}
+                </div>
+            </div>
+
+            <hr>
+
+            <!-- Change Password -->
+            <div class="settings-section">
+                <div class="settings-section-header">
+                    <h5>Change Password</h5>
+                    <small class="text-muted">For your security, we recommend choosing a strong password that you don't use elsewhere.</small>
+                </div>
+                <div class="settings-section-content">
+                    <form method="POST" action="{{ url_for('more.account_settings') }}">
+                        {{ password_form.hidden_tag() }}
+                        <div class="mb-3">
+                            {{ render_field(password_form.current_password, class="form-control", placeholder="Enter your current password") }}
+                        </div>
+                        <div class="mb-3">
+                            {{ render_field(password_form.new_password, class="form-control", placeholder="Enter your new password") }}
+                        </div>
+                        <div class="mb-3">
+                            {{ render_field(password_form.confirm_password, class="form-control", placeholder="Confirm your new password") }}
+                        </div>
+                        {{ password_form.submit(class="btn btn-primary") }}
+                    </form>
+                </div>
+            </div>
+
+            <hr>
+
+            <!-- Linked Accounts -->
+            <div class="settings-section">
+                <div class="settings-section-header">
+                    <h5>Linked Accounts</h5>
+                    <small class="text-muted">Connect social accounts for easier login. (Feature coming soon)</small>
+                </div>
+                <div class="settings-section-content">
+                    <div class="d-flex gap-2">
+                        <button class="btn btn-outline-secondary" disabled><i class="fab fa-google me-2"></i>Link Google</button>
+                        <button class="btn btn-outline-secondary" disabled><i class="fab fa-facebook me-2"></i>Link Facebook</button>
+                    </div>
+                </div>
+            </div>
+
+            <hr>
+
+            <!-- Deactivate Account -->
+            <div class="settings-section danger-zone">
+                 <div class="settings-section-header">
+                    <h5>Account Deactivation</h5>
+                </div>
+                <div class="settings-section-content">
+                    <p class="text-muted">This action is irreversible. All your data, including posts, comments, and messages, will be permanently deleted.</p>
+                    <button type="button" class="btn btn-sm btn-danger" data-bs-toggle="modal" data-bs-target="#deactivateModal">
+                        Deactivate Account
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Deactivate Modal -->
+<div class="modal fade" id="deactivateModal" tabindex="-1" aria-labelledby="deactivateModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="deactivateModalLabel">Are you absolutely sure?</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>This action <strong>cannot</strong> be undone. This will permanently delete your account, posts, and all other associated data.</p>
+        <p>Please type your password to confirm you want to permanently delete your account.</p>
+        <form method="POST" action="{{ url_for('more.delete_account') }}">
+            <div class="mb-3">
+                <input type="password" name="password" class="form-control" placeholder="Enter your password" required>
+            </div>
+            <div class="d-grid">
+                <button type="submit" class="btn btn-danger">I understand the consequences, delete my account</button>
+            </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/more/edit_profile.html
+++ b/templates/more/edit_profile.html
@@ -1,0 +1,142 @@
+{% extends "feed/base.html" %}
+{% from "_form_helpers.html" import render_field %}
+
+{% block title %}Edit Profile{% endblock %}
+
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/forms.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/profile.css') }}">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.css">
+{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="row">
+        <div class="col-lg-8">
+            <div class="card">
+                <div class="card-header">
+                    <h1>Edit Profile</h1>
+                    <p class="text-muted mb-0">Changes you make here will be visible to others on your public profile.</p>
+                </div>
+                <div class="card-body">
+                    <form method="POST" action="{{ url_for('more.edit_profile') }}" enctype="multipart/form-data" class="form-container">
+                        {{ form.hidden_tag() }}
+
+                        <fieldset class="form-group">
+                            <legend class="border-bottom mb-4">Public Information</legend>
+                            {{ render_field(form.name, class="form-control", label_visible=true) }}
+                            {{ render_field(form.username, class="form-control", placeholder="e.g., your_handle", label_visible=true) }}
+                            {{ render_field(form.website, class="form-control", placeholder="https://yourlink.com", label_visible=true) }}
+                            {{ render_field(form.bio, class="form-control", rows="4", label_visible=true) }}
+                        </fieldset>
+
+                        <fieldset class="form-group mt-4">
+                            <legend class="border-bottom mb-4">Profile Media</legend>
+                            <div class="mb-3">
+                                {{ form.profile_photo.label(class="form-label") }}
+                                {{ form.profile_photo(class="form-control") }}
+                                {% if form.profile_photo.errors %}
+                                    <div class="invalid-feedback d-block">
+                                        {% for error in form.profile_photo.errors %}
+                                            <span>{{ error }}</span>
+                                        {% endfor %}
+                                    </div>
+                                {% endif %}
+                            </div>
+                             <div class="mb-3">
+                                {{ form.cover_photo.label(class="form-label") }}
+                                {{ form.cover_photo(class="form-control") }}
+                                {% if form.cover_photo.errors %}
+                                    <div class="invalid-feedback d-block">
+                                        {% for error in form.cover_photo.errors %}
+                                            <span>{{ error }}</span>
+                                        {% endfor %}
+                                    </div>
+                                {% endif %}
+                            </div>
+                        </fieldset>
+
+                        <div class="form-group mt-4">
+                            {{ form.submit(class="btn btn-primary") }}
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-4">
+            <div class="profile-preview-card">
+                <h5 class="card-title">Live Preview</h5>
+                <div class="cover-preview" id="cover-preview-box" style="background-image: url({{ url_for('static', filename=(current_user.cover_photo or 'images/course_placeholder.jpg')) }});">
+                    <img id="profile-pic-preview-img" src="{{ url_for('static', filename='profile_pics/' + current_user.profile_pic) }}" alt="Profile Preview" class="profile-pic-preview">
+                </div>
+                <div class="info-preview">
+                    <h5 id="name-preview">{{ current_user.name }}</h5>
+                    <p id="username-preview">@{{ current_user.username or 'username' }}</p>
+                    <p id="bio-preview" class="text-muted">{{ current_user.bio or 'Your bio will appear here.' }}</p>
+                    <a href="#" id="website-preview" class="website-preview-link" target="_blank">{{ current_user.website or 'yourwebsite.com' }}</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Live preview for text fields
+    const nameInput = document.getElementById('name');
+    const usernameInput = document.getElementById('username');
+    const bioInput = document.getElementById('bio');
+    const websiteInput = document.getElementById('website');
+
+    const namePreview = document.getElementById('name-preview');
+    const usernamePreview = document.getElementById('username-preview');
+    const bioPreview = document.getElementById('bio-preview');
+    const websitePreview = document.getElementById('website-preview');
+
+    if(nameInput) nameInput.addEventListener('input', () => { namePreview.textContent = nameInput.value; });
+    if(usernameInput) usernameInput.addEventListener('input', () => { usernamePreview.textContent = '@' + usernameInput.value; });
+    if(bioInput) bioInput.addEventListener('input', () => { bioPreview.textContent = bioInput.value; });
+    if(websiteInput) {
+        websiteInput.addEventListener('input', () => {
+            websitePreview.textContent = websiteInput.value || 'yourwebsite.com';
+            websitePreview.href = websiteInput.value;
+        });
+    }
+
+    // Live preview for images
+    const profilePhotoInput = document.getElementById('profile_photo');
+    const coverPhotoInput = document.getElementById('cover_photo');
+    const profilePicPreview = document.getElementById('profile-pic-preview-img');
+    const coverPreviewBox = document.getElementById('cover-preview-box');
+
+    if(profilePhotoInput) {
+        profilePhotoInput.addEventListener('change', function(event) {
+            if(event.target.files[0]) {
+                const reader = new FileReader();
+                reader.onload = function(e) {
+                    profilePicPreview.src = e.target.result;
+                }
+                reader.readAsDataURL(event.target.files[0]);
+            }
+        });
+    }
+
+    if(coverPhotoInput) {
+        coverPhotoInput.addEventListener('change', function(event) {
+            if(event.target.files[0]) {
+                const reader = new FileReader();
+                reader.onload = function(e) {
+                    coverPreviewBox.style.backgroundImage = `url(${e.target.result})`;
+                }
+                reader.readAsDataURL(event.target.files[0]);
+            }
+        });
+    }
+});
+</script>
+{% endblock %}

--- a/templates/more/index.html
+++ b/templates/more/index.html
@@ -89,40 +89,31 @@
         </ul>
     </div>
 
-    <!-- Account & Settings Section -->
+    <!-- Profile & Identity Section -->
     <div class="more-section">
-        <div class="more-section-header">Account & Settings</div>
+        <div class="more-section-header">Profile & Identity</div>
         <ul class="more-menu-list">
             <li class="more-menu-item">
-                <a href="{{ url_for('feed.profile', user_id=current_user.id) }}">
+                <a href="{{ url_for('more.edit_profile') }}">
                     <span class="icon"><i class="fas fa-user-edit"></i></span>
                     <span class="label">Edit Profile</span>
                     <span class="chevron"><i class="fas fa-chevron-right"></i></span>
                 </a>
             </li>
             <li class="more-menu-item">
-                <a href="{{ url_for('more.settings') }}">
-                    <span class="icon"><i class="fas fa-cog"></i></span>
+                <a href="{{ url_for('more.account_settings') }}">
+                    <span class="icon"><i class="fas fa-user-cog"></i></span>
                     <span class="label">Account Settings</span>
                     <span class="chevron"><i class="fas fa-chevron-right"></i></span>
                 </a>
             </li>
             <li class="more-menu-item">
-                <a href="{{ url_for('more.blocked_users') }}">
-                    <span class="icon"><i class="fas fa-user-slash"></i></span>
-                    <span class="label">Blocked Users</span>
+                <a href="{{ url_for('more.privacy_security') }}">
+                    <span class="icon"><i class="fas fa-shield-alt"></i></span>
+                    <span class="label">Privacy & Security</span>
                     <span class="chevron"><i class="fas fa-chevron-right"></i></span>
                 </a>
             </li>
-            {% if current_user.is_premium %}
-            <li class="more-menu-item">
-                <a href="{{ url_for('more.profile_appearance_settings') }}">
-                    <span class="icon"><i class="fas fa-paint-brush"></i></span>
-                    <span class="label">Profile Appearance</span>
-                    <span class="chevron"><i class="fas fa-chevron-right"></i></span>
-                </a>
-            </li>
-            {% endif %}
             <li class="more-menu-item">
                 <div class="theme-toggle-container">
                     <div style="display: flex; align-items: center;">

--- a/templates/more/privacy_security.html
+++ b/templates/more/privacy_security.html
@@ -1,0 +1,99 @@
+{% extends "feed/base.html" %}
+{% from "_form_helpers.html" import render_field %}
+
+{% block title %}Privacy & Security{% endblock %}
+
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/forms.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/settings.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="card settings-card">
+        <div class="card-header">
+            <h1>Privacy & Security</h1>
+            <p class="text-muted mb-0">Control your privacy, manage account security, and view login history.</p>
+        </div>
+        <div class="card-body">
+            <!-- Security Status -->
+            <div class="alert alert-warning" role="alert">
+              <i class="fas fa-exclamation-triangle me-2"></i>
+              <strong>Add 2FA for better security.</strong>
+              <a href="#2fa-section" class="alert-link ms-2">Set up now</a>
+            </div>
+
+            <!-- Blocked Users -->
+            <div class="settings-section">
+                <div class="settings-section-header">
+                    <h5>Blocked Users</h5>
+                    <small class="text-muted">Manage the accounts you have blocked.</small>
+                </div>
+                <div class="settings-section-content">
+                    <p>You have {{ blocked_users_count }} blocked user(s).</p>
+                    <a href="{{ url_for('more.blocked_users') }}" class="btn btn-sm btn-outline-secondary">View and Manage Blocked Users</a>
+                </div>
+            </div>
+
+            <hr>
+
+            <!-- Two-Factor Authentication -->
+            <div class="settings-section" id="2fa-section">
+                <div class="settings-section-header">
+                    <h5>Two-Factor Authentication (2FA)</h5>
+                    <small class="text-muted">Add an extra layer of security to your account.</small>
+                </div>
+                <div class="settings-section-content">
+                    <p>2FA is currently <strong>disabled</strong>.</p>
+                    <button class="btn btn-primary" disabled>Enable 2FA (Coming Soon)</button>
+                </div>
+            </div>
+
+            <hr>
+
+            <!-- Login History / Devices -->
+            <div class="settings-section">
+                <div class="settings-section-header">
+                    <h5>Login History</h5>
+                    <small class="text-muted">Review recent login activity on your account. (Feature coming soon)</small>
+                </div>
+                <div class="settings-section-content">
+                    <ul class="list-group">
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            <div>
+                                <i class="fas fa-desktop me-2 text-muted"></i>
+                                <strong>Chrome on Windows</strong>
+                                <br>
+                                <small class="text-muted">New York, USA (Approx. location)</small>
+                            </div>
+                            <span class="badge bg-light text-dark">Active Now</span>
+                        </li>
+                    </ul>
+                    <button class="btn btn-sm btn-outline-danger mt-3" disabled>Log Out All Other Sessions</button>
+                </div>
+            </div>
+
+             <hr>
+
+            <!-- Who can see my posts -->
+            <div class="settings-section">
+                <div classs="settings-section-header">
+                    <h5>Post Visibility</h5>
+                    <small class="text-muted">Set the default privacy for your new posts. (Feature coming soon)</small>
+                </div>
+                <div class="settings-section-content">
+                    <form>
+                         <select class="form-select" disabled>
+                            <option selected>Public</option>
+                            <option>Followers</option>
+                            <option>Private</option>
+                        </select>
+                    </form>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This commit introduces a new "Profile & Identity" section in the "More" menu, which is broken down into three pages:

- Edit Profile: Allows users to update their public profile information, including name, username, bio, website, profile picture, and cover photo.
- Account Settings: Provides options for managing account credentials, such as changing the password and deleting the account.
- Privacy & Security: A placeholder for future privacy and security settings, currently linking to the existing "Blocked Users" page.

The implementation includes new routes, forms, and templates for these pages, as well as updates to the User model to support the new profile fields.