### PR TITLE
feat: Implement image cropping for profile photos

### DIFF
--- a/templates/more/edit_profile.html
+++ b/templates/more/edit_profile.html
@@ -20,7 +20,7 @@
                     <p class="text-muted mb-0">Changes you make here will be visible to others on your public profile.</p>
                 </div>
                 <div class="card-body">
-                    <form method="POST" action="{{ url_for('more.edit_profile') }}" enctype="multipart/form-data" class="form-container">
+                    <form id="edit-profile-form" method="POST" action="{{ url_for('more.edit_profile') }}" enctype="multipart/form-data" class="form-container">
                         {{ form.hidden_tag() }}
 
                         <fieldset class="form-group">
@@ -35,7 +35,7 @@
                             <legend class="border-bottom mb-4">Profile Media</legend>
                             <div class="mb-3">
                                 {{ form.profile_photo.label(class="form-label") }}
-                                {{ form.profile_photo(class="form-control") }}
+                                {{ form.profile_photo(class="form-control", **{'data-crop-type': 'profile'}) }}
                                 {% if form.profile_photo.errors %}
                                     <div class="invalid-feedback d-block">
                                         {% for error in form.profile_photo.errors %}
@@ -46,7 +46,7 @@
                             </div>
                              <div class="mb-3">
                                 {{ form.cover_photo.label(class="form-label") }}
-                                {{ form.cover_photo(class="form-control") }}
+                                {{ form.cover_photo(class="form-control", **{'data-crop-type': 'cover'}) }}
                                 {% if form.cover_photo.errors %}
                                     <div class="invalid-feedback d-block">
                                         {% for error in form.cover_photo.errors %}
@@ -80,6 +80,27 @@
         </div>
     </div>
 </div>
+
+<!-- Cropper Modal -->
+<div class="modal fade" id="cropperModal" tabindex="-1" aria-labelledby="cropperModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="cropperModalLabel">Crop Image</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="img-container">
+            <img id="imageToCrop" src="">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="crop-button">Crop</button>
+      </div>
+    </div>
+  </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
@@ -87,7 +108,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    // Live preview for text fields
+    // --- Live Preview Logic ---
     const nameInput = document.getElementById('name');
     const usernameInput = document.getElementById('username');
     const bioInput = document.getElementById('bio');
@@ -108,35 +129,79 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    // Live preview for images
+    // --- Cropper.js Logic ---
+    const modalElement = document.getElementById('cropperModal');
+    const imageToCrop = document.getElementById('imageToCrop');
+    const cropButton = document.getElementById('crop-button');
     const profilePhotoInput = document.getElementById('profile_photo');
     const coverPhotoInput = document.getElementById('cover_photo');
-    const profilePicPreview = document.getElementById('profile-pic-preview-img');
-    const coverPreviewBox = document.getElementById('cover-preview-box');
+    let cropper;
+    let currentInputElement;
+    let currentCropType;
 
-    if(profilePhotoInput) {
-        profilePhotoInput.addEventListener('change', function(event) {
-            if(event.target.files[0]) {
-                const reader = new FileReader();
-                reader.onload = function(e) {
-                    profilePicPreview.src = e.target.result;
-                }
-                reader.readAsDataURL(event.target.files[0]);
-            }
-        });
+    const cropperModal = new bootstrap.Modal(modalElement);
+
+    function handleFileSelect(event) {
+        currentInputElement = event.target;
+        currentCropType = currentInputElement.dataset.cropType;
+        const file = currentInputElement.files[0];
+
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                imageToCrop.src = e.target.result;
+                cropperModal.show();
+            };
+            reader.readAsDataURL(file);
+        }
     }
 
-    if(coverPhotoInput) {
-        coverPhotoInput.addEventListener('change', function(event) {
-            if(event.target.files[0]) {
+    profilePhotoInput.addEventListener('change', handleFileSelect);
+    coverPhotoInput.addEventListener('change', handleFileSelect);
+
+    modalElement.addEventListener('shown.bs.modal', function () {
+        let aspectRatio = 16 / 9; // Default for cover photo
+        if (currentCropType === 'profile') {
+            aspectRatio = 1; // Square for profile picture
+        }
+
+        cropper = new Cropper(imageToCrop, {
+            aspectRatio: aspectRatio,
+            viewMode: 1,
+            autoCropArea: 0.8,
+        });
+    });
+
+    modalElement.addEventListener('hidden.bs.modal', function () {
+        cropper.destroy();
+        cropper = null;
+        // Reset the file input if the user cancels
+        currentInputElement.value = '';
+    });
+
+    cropButton.addEventListener('click', function() {
+        if (cropper) {
+            cropper.getCroppedCanvas().toBlob(function(blob) {
+                const file = new File([blob], 'cropped_image.png', { type: 'image/png' });
+                const dataTransfer = new DataTransfer();
+                dataTransfer.items.add(file);
+                currentInputElement.files = dataTransfer.files;
+
+                // Update live preview
                 const reader = new FileReader();
                 reader.onload = function(e) {
-                    coverPreviewBox.style.backgroundImage = `url(${e.target.result})`;
+                    if (currentCropType === 'profile') {
+                        document.getElementById('profile-pic-preview-img').src = e.target.result;
+                    } else {
+                        document.getElementById('cover-preview-box').style.backgroundImage = `url(${e.target.result})`;
+                    }
                 }
-                reader.readAsDataURL(event.target.files[0]);
-            }
-        });
-    }
+                reader.readAsDataURL(blob);
+
+                cropperModal.hide();
+            }, 'image/png');
+        }
+    });
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
This commit adds image cropping functionality to the 'Edit Profile' page. When a user uploads a profile or cover photo, a modal now appears allowing them to crop the image to the desired aspect ratio (1:1 for profile, 16:9 for cover).

This is implemented using the `cropper.js` library on the frontend. The cropped image data is then sent to the backend and saved, replacing the original uploaded file.