### PR TITLE
fix: Import forms in routes.py

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -6,6 +6,7 @@ import secrets
 import os
 from werkzeug.utils import secure_filename
 from models import User, Course, Category, CourseComment, Lesson, LibraryMaterial, Assignment, AssignmentSubmission, Quiz, FinalExam, QuizSubmission, ExamSubmission, Enrollment, LessonCompletion, Module, Certificate, CertificateRequest, LibraryPurchase, ChatRoom, ChatRoomMember, MutedRoom, UserLastRead, ChatMessage, ExamViolation, GroupRequest, Choice, Answer, Status, StatusView, Community, Poll, ChatClearTimestamp, SupportTicket, MutedStatusUser, LinkPreview, FCMToken, CallHistory, Post
+from forms import EditProfileForm, AddBadgeForm, AddSocialLinkForm, AddCertificateForm
 from extensions import db
 from utils import save_chat_file, save_status_file, get_or_create_platform_setting, is_contact, get_or_create_private_room
 from datetime import timedelta


### PR DESCRIPTION
This commit fixes a `NameError` that was occurring on the profile page. The error was caused by a missing import statement for the new forms in `routes.py`.