### PR TITLE
Feat: Implement 'My Courses' page and navigation

### DIFF
--- a/static/css/dashboard_student.css
+++ b/static/css/dashboard_student.css
@@ -243,3 +243,88 @@
         opacity: 1;
     }
 }
+
+/* --- Dashboard Navigation --- */
+.dashboard-nav {
+    display: flex;
+    border-bottom: 1px solid var(--divider);
+    margin-bottom: 2rem;
+    overflow-x: auto;
+}
+
+.dashboard-nav .nav-tab {
+    padding: 1rem 1.5rem;
+    color: var(--color-secondary);
+    text-decoration: none;
+    font-weight: 600;
+    border-bottom: 2px solid transparent;
+    transition: color 0.2s, border-color 0.2s;
+    white-space: nowrap;
+}
+
+.dashboard-nav .nav-tab:hover {
+    color: var(--color-primary);
+}
+
+.dashboard-nav .nav-tab.active {
+    color: var(--color-accent);
+    border-bottom-color: var(--color-accent);
+}
+
+/* --- My Courses Page --- */
+.my-courses-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.course-card {
+    background-color: var(--bg-secondary);
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid var(--divider);
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.course-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 15px -3px rgba(0,0,0,0.07), 0 4px 6px -2px rgba(0,0,0,0.05);
+}
+
+[data-theme="dark"] .course-card {
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+}
+
+.course-card-img {
+    width: 100%;
+    height: 150px;
+    object-fit: cover;
+}
+
+.course-card-body {
+    padding: 1.5rem;
+}
+
+.course-card-title {
+    font-family: 'Merriweather', serif;
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+}
+
+.course-card-title a {
+    color: var(--color-primary);
+    text-decoration: none;
+}
+
+.course-card-instructor {
+    color: var(--color-secondary);
+    font-size: 0.9rem;
+    margin-bottom: 1rem;
+}
+
+.course-card-progress {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}

--- a/templates/my_courses.html
+++ b/templates/my_courses.html
@@ -1,0 +1,42 @@
+{% extends "layouts/dashboard_layout.html" %}
+
+{% block dashboard_content %}
+<!-- Header -->
+<div class="content-header">
+    <h1 class="fade-in">My Courses</h1>
+    <p class="fade-in" style="animation-delay: 0.2s;">All your enrolled courses in one place.</p>
+</div>
+
+<!-- Horizontal Navigation -->
+<nav class="dashboard-nav">
+    <a href="{{ url_for('main.student_dashboard') }}" class="nav-tab">Dashboard</a>
+    <a href="{{ url_for('main.my_courses') }}" class="nav-tab active">My Courses</a>
+    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Assignments</a>
+    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Grades</a>
+    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Certificates</a>
+    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Announcements</a>
+</nav>
+
+<!-- My Courses Grid -->
+<div class="my-courses-grid">
+    {% for data in enrollment_data %}
+    <div class="course-card">
+        <a href="{{ url_for('main.course_detail', course_id=data.enrollment.course.id) }}">
+            <img src="{{ url_for('static', filename='images/course_placeholder.jpg') }}" alt="{{ data.enrollment.course.title }}" class="course-card-img">
+        </a>
+        <div class="course-card-body">
+            <h3 class="course-card-title"><a href="{{ url_for('main.course_detail', course_id=data.enrollment.course.id) }}">{{ data.enrollment.course.title }}</a></h3>
+            <p class="course-card-instructor">{{ data.enrollment.course.instructor.name }}</p>
+            <div class="course-card-progress">
+                <div class="progress-bar-wrapper">
+                    <div class="progress-bar-gradient" style="width: {{ data.progress.percentage | default(0) }}%;"></div>
+                </div>
+                <span class="progress-percentage">{{ "%.0f"|format(data.progress.percentage | default(0)) }}%</span>
+            </div>
+        </div>
+    </div>
+    {% else %}
+    <p>You are not enrolled in any courses yet. <a href="{{ url_for('main.courses') }}">Browse courses</a>.</p>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/templates/student_dashboard.html
+++ b/templates/student_dashboard.html
@@ -7,6 +7,16 @@
     <p class="fade-in" style="animation-delay: 0.2s;">Your personalized student dashboard.</p>
 </div>
 
+<!-- Horizontal Navigation -->
+<nav class="dashboard-nav">
+    <a href="{{ url_for('main.student_dashboard') }}" class="nav-tab active">Dashboard</a>
+    <a href="{{ url_for('main.my_courses') }}" class="nav-tab">My Courses</a>
+    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Assignments</a>
+    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Grades</a>
+    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Certificates</a>
+    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Announcements</a>
+</nav>
+
 <!-- Main Grid -->
 <div class="dashboard-main-grid">
 


### PR DESCRIPTION
This commit introduces the 'My Courses' page and adds a horizontal navigation bar to the student dashboard area, continuing the dashboard redesign.

Key changes include:
- A new route `/student/my-courses` that fetches and displays a student's enrolled courses.
- A new template `my_courses.html` that renders the courses in a grid of styled cards, each with a progress bar.
- A horizontal navigation bar has been added to the top of the student dashboard and 'My Courses' pages, allowing for future expansion of the student-facing sections.
- The 'Dashboard' and 'My Courses' tabs are correctly marked as active on their respective pages.
- New CSS styles have been added to `dashboard_student.css` to support the new course card grid layout.