### PR TITLE
Feat: Implement 'Grades' page for student dashboard

### DIFF
--- a/static/css/dashboard_student.css
+++ b/static/css/dashboard_student.css
@@ -391,3 +391,61 @@
     background-color: #28a745;
     color: white;
 }
+
+/* --- Grades Page --- */
+.grades-container {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.course-grade-section {
+    background-color: var(--bg-secondary);
+    border-radius: 12px;
+    padding: 1.5rem;
+    border: 1px solid var(--divider);
+}
+
+.course-grade-title {
+    font-family: 'Merriweather', serif;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-primary);
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--divider);
+}
+
+.grade-items-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.grade-item {
+    display: grid;
+    grid-template-columns: 100px 1fr auto;
+    align-items: center;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid var(--divider);
+}
+
+.grade-items-list .grade-item:last-child {
+    border-bottom: none;
+}
+
+.grade-item-type {
+    font-weight: 600;
+    color: var(--color-secondary);
+    font-size: 0.9rem;
+}
+
+.grade-item-title {
+    color: var(--color-primary);
+}
+
+.grade-item-score {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: var(--color-accent);
+}

--- a/templates/assignments.html
+++ b/templates/assignments.html
@@ -12,7 +12,7 @@
     <a href="{{ url_for('main.student_dashboard') }}" class="nav-tab">Dashboard</a>
     <a href="{{ url_for('main.my_courses') }}" class="nav-tab">My Courses</a>
     <a href="{{ url_for('main.assignments') }}" class="nav-tab active">Assignments</a>
-    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Grades</a>
+    <a href="{{ url_for('main.grades') }}" class="nav-tab">Grades</a>
     <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Certificates</a>
     <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Announcements</a>
 </nav>

--- a/templates/grades.html
+++ b/templates/grades.html
@@ -1,0 +1,45 @@
+{% extends "layouts/dashboard_layout.html" %}
+
+{% block dashboard_content %}
+<!-- Header -->
+<div class="content-header">
+    <h1 class="fade-in">Grades</h1>
+    <p class="fade-in" style="animation-delay: 0.2s;">Your official gradebook.</p>
+</div>
+
+<!-- Horizontal Navigation -->
+<nav class="dashboard-nav">
+    <a href="{{ url_for('main.student_dashboard') }}" class="nav-tab">Dashboard</a>
+    <a href="{{ url_for('main.my_courses') }}" class="nav-tab">My Courses</a>
+    <a href="{{ url_for('main.assignments') }}" class="nav-tab">Assignments</a>
+    <a href="{{ url_for('main.grades') }}" class="nav-tab active">Grades</a>
+    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Certificates</a>
+    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Announcements</a>
+</nav>
+
+<!-- Grades View -->
+<div class="grades-container">
+    {% if grades_data %}
+        {% for course_title, grades in grades_data.items() %}
+        <div class="course-grade-section">
+            <h2 class="course-grade-title">{{ course_title }}</h2>
+            <div class="grade-items-list">
+                {% for grade in grades %}
+                <div class="grade-item">
+                    <span class="grade-item-type">{{ grade.type }}</span>
+                    <span class="grade-item-title">{{ grade.title }}</span>
+                    <span class="grade-item-score">{{ grade.grade }}</span>
+                </div>
+                {% else %}
+                <div class="grade-item">
+                    <span>No grades available for this course yet.</span>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        {% endfor %}
+    {% else %}
+        <p>No grades available yet.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/my_courses.html
+++ b/templates/my_courses.html
@@ -12,7 +12,7 @@
     <a href="{{ url_for('main.student_dashboard') }}" class="nav-tab">Dashboard</a>
     <a href="{{ url_for('main.my_courses') }}" class="nav-tab active">My Courses</a>
     <a href="{{ url_for('main.assignments') }}" class="nav-tab">Assignments</a>
-    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Grades</a>
+    <a href="{{ url_for('main.grades') }}" class="nav-tab">Grades</a>
     <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Certificates</a>
     <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Announcements</a>
 </nav>

--- a/templates/student_dashboard.html
+++ b/templates/student_dashboard.html
@@ -12,7 +12,7 @@
     <a href="{{ url_for('main.student_dashboard') }}" class="nav-tab active">Dashboard</a>
     <a href="{{ url_for('main.my_courses') }}" class="nav-tab">My Courses</a>
     <a href="{{ url_for('main.assignments') }}" class="nav-tab">Assignments</a>
-    <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Grades</a>
+    <a href="{{ url_for('main.grades') }}" class="nav-tab">Grades</a>
     <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Certificates</a>
     <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Announcements</a>
 </nav>


### PR DESCRIPTION
This commit introduces the 'Grades' page, accessible via the horizontal navigation bar in the student dashboard area. This page provides students with a comprehensive view of their academic performance.

Key changes include:
- A new route `/student/grades` that fetches all of a student's graded items, including assignments, quizzes, and final exams.
- The data is processed and grouped by course to create a clear, organized gradebook structure.
- A new template `grades.html` that renders the grades in a formal gradebook style, with sections for each course.
- The horizontal navigation bar across all student dashboard pages has been updated to correctly link to the new 'Grades' page.
- New CSS styles have been added to `dashboard_student.css` to support the gradebook layout, ensuring it matches the new premium dark theme.