### PR TITLE
feat(navigation): Add GloobaApp links to all dashboards

### DIFF
--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -58,6 +58,13 @@
             <p class="card-subtitle">Oversee chat rooms and communications.</p>
         </a>
 
+        <!-- GloobaApp -->
+        <a href="{{ url_for('glooba.glooba_home') }}" class="glass-card glow-cyan">
+            <div class="card-icon"><i class="fas fa-rocket"></i></div>
+            <h3 class="card-title">GloobaApp</h3>
+            <p class="card-subtitle">Access the GloobaApp interface.</p>
+        </a>
+
         <!-- Manage Group Requests -->
         <a href="{{ url_for('admin.manage_group_requests') }}" class="glass-card glow-teal">
             <div class="card-icon"><i class="fas fa-user-friends"></i></div>

--- a/templates/instructor/dashboard.html
+++ b/templates/instructor/dashboard.html
@@ -7,6 +7,12 @@
         <p>Manage your courses and engage with your students.</p>
     </div>
 
+    <!-- Horizontal Navigation -->
+    <nav class="dashboard-nav">
+        <a href="{{ url_for('instructor.dashboard') }}" class="nav-tab active">Dashboard</a>
+        <a href="{{ url_for('glooba.glooba_home') }}" class="nav-tab">GloobaApp</a>
+    </nav>
+
     <div class="dashboard-grid">
         <!-- My Courses (Teaching) -->
         <div class="card col-span-2">

--- a/templates/student_dashboard.html
+++ b/templates/student_dashboard.html
@@ -14,6 +14,7 @@
     <a href="{{ url_for('main.assignments') }}" class="nav-tab">Assignments</a>
     <a href="{{ url_for('main.grades') }}" class="nav-tab">Grades</a>
     <a href="{{ url_for('main.certificates') }}" class="nav-tab">Certificates</a>
+    <a href="{{ url_for('glooba.glooba_home') }}" class="nav-tab">GloobaApp</a>
     <a href="{{ url_for('main.placeholder') }}" class="nav-tab">Announcements</a>
 </nav>
 


### PR DESCRIPTION
This commit adds a navigation link to the GloobaApp feature on the Student, Instructor, and Admin dashboards to ensure it is easily accessible to all user roles.

Changes include:
- Added a 'GloobaApp' tab to the navigation bar in `templates/student_dashboard.html`.
- Added a new navigation bar with a 'GloobaApp' tab to `templates/instructor/dashboard.html` for consistency.
- Added a 'GloobaApp' card to the action grid in `templates/admin/dashboard.html`.