### PR TITLE
fix(routing): Correct feed URL prefix and verify navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,7 +81,7 @@ def create_app(config_object=None):
     app.register_blueprint(admin_bp)
 
     from feed_world_routes import feed as feed_blueprint
-    app.register_blueprint(feed_blueprint)
+    app.register_blueprint(feed_blueprint, url_prefix='/feed')
 
     from more_routes import more_bp
     app.register_blueprint(more_bp)


### PR DESCRIPTION
This commit resolves a routing conflict where the feed blueprint's `/home` route was overriding the main application's home page.

- A `url_prefix='/feed'` has been added to the feed blueprint registration in `app.py`. This ensures all feed-related routes are correctly namespaced under `/feed`.
- The 'Feed' navigation links in the shared dashboard layout now correctly point to the namespaced `/feed/home` route.
- Verified that the links work as expected for both student and instructor roles.