### PR TITLE
Rebuild suggestion page with Facebook-style UI and location filtering

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -34,8 +34,13 @@ def get_engine_url():
 
 # add your model's MetaData object here
 # for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
+#
+# To ensure models are registered for autogeneration, import them here.
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import models
+
 config.set_main_option('sqlalchemy.url', get_engine_url())
 target_db = current_app.extensions['migrate'].db
 

--- a/migrations/versions/dcde4f471e3c_add_location_fields_to_user.py
+++ b/migrations/versions/dcde4f471e3c_add_location_fields_to_user.py
@@ -1,0 +1,30 @@
+"""Add location fields to User
+
+Revision ID: dcde4f471e3c
+Revises: 30cc30d9cb4d
+Create Date: 2025-10-01 14:54:48.772296
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'dcde4f471e3c'
+down_revision = '30cc30d9cb4d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('city', sa.String(length=100), nullable=True))
+        batch_op.add_column(sa.Column('state', sa.String(length=100), nullable=True))
+        batch_op.add_column(sa.Column('country', sa.String(length=100), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('country')
+        batch_op.drop_column('state')
+        batch_op.drop_column('city')


### PR DESCRIPTION
This commit revamps the user suggestion page to align with a more modern, Facebook-like design. It also resolves a critical bug that prevented user registration due to a database schema mismatch.

Key changes include:
- Redesigned the suggestions page with a grid-based layout for user cards.
- Implemented a feature to filter user suggestions by city and state.
- Updated the `User` model to include `city`, `state`, and `country` fields to support location-based filtering.
- Added a new route (`/feed/suggestions`) to handle both the initial loading of random user suggestions and location-based searches.
- Created a database migration to add the new location fields to the `user` table, fixing the user registration error.