### PR TITLE
feat: Implement Novara-style feed world profile page

### DIFF
--- a/static/css/novara_profile.css
+++ b/static/css/novara_profile.css
@@ -167,30 +167,21 @@ body {
 
 /* Reels Feed */
 #reels-content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 30px; /* Increased space between videos */
-    background-color: #fafafa; /* Lighter background for the feed area */
-    padding: 20px 0;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 28px;
 }
-
 .reel-item {
-    width: 100%;
-    max-width: 380px; /* A bit narrower for a more mobile-like feel */
-    height: 675px; /* Taller aspect ratio */
-    border-radius: 12px;
-    overflow: hidden;
-    border: 1px solid #dbdbdb;
     position: relative;
-    background-color: #000; /* Black background for the video container */
+    padding-bottom: 160%; /* Aspect ratio for vertical videos */
 }
-
 .reel-item video {
+    position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
-    object-fit: cover; /* Cover the container, might crop a bit */
-    display: block;
+    object-fit: cover;
 }
 
 /* FAB */


### PR DESCRIPTION
This commit introduces a new profile page for the "feed world" with a clean, "Novara Style" design, as requested.

Key features include:
- A new route `/feed/profile/<username>` and template `templates/feed/novara_profile.html`.
- A dedicated stylesheet `static/css/novara_profile.css` for the new design.
- The profile page displays the user's profile picture, bio, and follower/following counts.
- Tabbed navigation for "Posts," "Photos," and "Reels".
- The "Posts" tab displays all of the user's posts in a vertical feed.
- The "Photos" and "Reels" tabs display content in a 3-column grid view.
- The backend route now pre-filters posts for efficiency.
- A floating action button (FAB) for creating new posts.
- Conditional logic to display "Edit Profile" or "Follow/Unfollow" buttons.
- A placeholder page for "Edit Profile" has been created to ensure the link is not dead.

Known limitations due to a persistent server startup issue that blocked full testing:
- The "Message" and "More" buttons are not functional.
- Post engagement actions (Like, Comment, Share) are not functional.
- The "Reels" tab does not have the requested autoplay/TikTok-style UI for the global feed (this is a separate feature).
- The "Photos" tab does not have the requested fullscreen gallery view.